### PR TITLE
Potential fix for code scanning alert no. 11: Implicit narrowing conversion in compound assignment

### DIFF
--- a/plugins/com.tlcsdm.eclipse.minimap/src/com/tlcsdm/eclipse/minimap/util/SWTExtensions.java
+++ b/plugins/com.tlcsdm.eclipse.minimap/src/com/tlcsdm/eclipse/minimap/util/SWTExtensions.java
@@ -1411,16 +1411,16 @@ public class SWTExtensions {
 	}
 
 	public Point scale(Point p, double scale) {
-		p.x *= scale;
-		p.y *= scale;
+		p.x = (int) (p.x * scale);
+		p.y = (int) (p.y * scale);
 		return p;
 	}
 
 	public Rectangle scale(Rectangle p, double scale) {
-		p.x *= scale;
-		p.y *= scale;
-		p.width *= scale;
-		p.height *= scale;
+		p.x = (int) (p.x * scale);
+		p.y = (int) (p.y * scale);
+		p.width = (int) (p.width * scale);
+		p.height = (int) (p.height * scale);
 		return p;
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/tlcsdm/eclipse-minimap/security/code-scanning/11](https://github.com/tlcsdm/eclipse-minimap/security/code-scanning/11)

Best fix: replace compound assignments on `int` fields with explicit assignment using controlled conversion from `double` to `int`.  
In this file, update the `scale(Point p, double scale)` and `scale(Rectangle p, double scale)` methods so each field uses:

- `field = (int) (field * scale);`

This removes implicit narrowing in compound assignment while preserving current truncation behavior (toward zero), so functionality remains unchanged.

Edit region: `plugins/com.tlcsdm.eclipse.minimap/src/com/tlcsdm/eclipse/minimap/util/SWTExtensions.java`, around lines 1413–1424.  
No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
